### PR TITLE
fix(Roleplay points): Not counted points from the 'I want to only nam…

### DIFF
--- a/src/data/roleplays.json
+++ b/src/data/roleplays.json
@@ -37,13 +37,11 @@
       "Roless": 2,
       "Lumiose": 1,
       "Ecologist Hegemony": 1,
-      "Jutsa": 1,
       "Garbelia": 2,
       "Nordustra": 1,
       "Cacusia": 2,
       "Chaplin": 1,
       "Green Empire Karaa": 1,
-      "Azure Mines": 1,
       "Realize": 1,
       "Furilisca": 1,
       "Anxious and Kevin": 2


### PR DESCRIPTION
…e my players' that didn't use the Team Builder Tool, because it is not the same as the Customize My Team option